### PR TITLE
fix: security audit remediation and Cosmos EVM v0.6.0 alignment

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,2 @@
 tests/systemtests/Counter
+docs/superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@
 
 ### DEPENDENCIES
 
+- Upgrade Cosmos SDK v0.53.4 → v0.53.6 (CometBFT v0.38.21, gogoproto v1.7.2)
+
 ### BUG FIXES
+
+- Security audit: add nil check for GetAccount in CanTransfer (C-02)
+- Security audit: add reserve balance pre-validation in precisebank (C-01)
+- Security audit: wrap ERC20 conversion in CacheContext for atomicity (C-03/M-06)
+- Security audit: strengthen Transfer event validation with full parameter check (H-01)
+- Security audit: add precompile input validation for commission/delegation bounds (H-02)
+- Security audit: return error for self-destructed token pairs (M-05)
+- Security audit: prevent nil panic in IBC callback BalanceOf (M-03)
 
 - [\#471](https://github.com/zenanetwork/zena/pull/471) Notify new block for mempool in time
 - [\#492](https://github.com/zenanetwork/zena/pull/492) Duplicate case switch to avoid empty execution block
@@ -32,6 +42,12 @@
 
 ### IMPROVEMENTS
 
+- Cosmos EVM v0.6.0: pass StateDB as explicit parameter to EVM call functions
+- Cosmos EVM v0.6.0: port counter-based StateDB event architecture (processedEventsCount)
+- Cosmos EVM v0.6.0: remove custom IBC transfer wrapper, use official ibc-go transfer keeper
+- Cosmos EVM v0.6.0: restore ERC20 conversion in ICS20 precompile (transferWithStateDB)
+- Cosmos EVM v0.6.0: add SetAddressCodec with EVM codec for transfer keeper
+- Security audit: add ERC20-PreciseBank cross-module integration tests (H-05)
 - [\#708](https://github.com/zenanetwork/zena/pull/708) Add configurable testnet validator powers
 - [\#698](https://github.com/zenanetwork/zena/pull/698) Expose mempool configuration flags and move mempool configuration in app.go to helper
 - [\#538](https://github.com/zenanetwork/zena/pull/538) Optimize `eth_estimateGas` gRPC path: short-circuit plain transfers, add optimistic gas bound based on `MaxUsedGas`.


### PR DESCRIPTION
## Summary

보안 감사 지적사항 수정 및 Cosmos EVM v0.6.0 정합성 업그레이드를 포함합니다.

### Security Audit Fixes

**CRITICAL (3건)**
- **C-01**: `x/precisebank` reserve balance 사전 검증 추가 — carry 연산 중 panic 방지
- **C-02**: `ante/evm` CanTransfer에서 GetAccount() nil 체크 추가
- **C-03/M-06**: ERC20 conversion 함수를 CacheContext로 래핑하여 원자성 보장

**HIGH (3건 수정, 2건 불필요 판정 후 revert)**
- **H-01**: Transfer 이벤트 검증에 from/to/amount 파라미터 검증 강화
- **H-02**: Precompile 공통 입력 검증 유틸리티 추가
- **H-05**: ERC20-PreciseBank cross-module 통합 테스트 추가
- **H-03, H-04**: 분석 후 불필요 판정, revert 완료

**MEDIUM (2건)**
- **M-03**: IBC callback BalanceOf nil panic 방지
- **M-05**: Self-destruct된 토큰 페어에 대해 명시적 에러 반환

### Cosmos EVM v0.6.0 Alignment

- StateDB를 EVM call 함수의 외부 파라미터로 변경
- StateDB 이벤트 관리를 카운터 기반(processedEventsCount)으로 포팅
- 커스텀 IBC Transfer wrapper 제거 → 공식 ibc-go transfer keeper 사용
- ICS20 precompile에 ERC